### PR TITLE
Ra recent aside 2

### DIFF
--- a/controllers/api/ponderController.js
+++ b/controllers/api/ponderController.js
@@ -41,8 +41,9 @@ router.get("/", (req, res) => {
     .then(ponders => {
         let recent = [ponders[ponders.length-1],ponders[ponders.length-2],ponders[ponders.length-3]];
         const ponder = recent.map((post) => post.get({ plain: true }));
+        console.log(ponder);
         // res.json(ponder);
-        res.render('random', { ponder });
+        res.render('recent', { ponder });
     });
 });
 
@@ -105,6 +106,5 @@ router.delete("/:id", (req, res) => {
         where: {id: req.params.id}
     });
 });
-
 
 module.exports = router;

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -1,7 +1,7 @@
 const router = require('express').Router();
 const htmlController = require("./htmlController");
 const routes = require("./api");
-const { User } = require('../models');
+const { User, Ponder } = require('../models');
 
 
 router.use("/api", routes);
@@ -11,12 +11,21 @@ router.use("/", htmlController)
 
 //Homepage if not logged in
 router.get("/", (req, res) => {
-    if (req.session.user) {
-      res.redirect('/active')
-    }
-  res.render('form', {
-      layout: 'main'
-    });
+
+  Ponder.findAll({include: [User]})
+  .then(ponders => {
+      let recent = [ponders[ponders.length-1],ponders[ponders.length-2],ponders[ponders.length-3]];
+      const ponder = recent.map((post) => post.get({ plain: true }));
+      // res.json(ponder);
+      res.render('form', { ponder });
+  });
+
+  //   if (req.session.user) {
+  //     res.redirect('/active')
+  //   }
+  // res.render('form', {
+  //     layout: 'main'
+  //   });
   });
 
 //Homepage if logged in  

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -55,15 +55,6 @@ body {
 
 }
 
-.container{
-    display: flex;
-   height: 100vh;
-   width: 100%;
-   align-items: center;
-   justify-content: center;
-
-}
-
 .comment-btn {
    
 }
@@ -77,6 +68,15 @@ body {
 }
 
 .go-fishing-btn {
+
+}
+
+.container{
+   display: flex;
+  height: 100vh;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
 
 }
 

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -6,9 +6,9 @@
     --pond-color: #8ACDEA;
 }
 
-.ponder-nav {
-    display: flex;
-    color: var(--nav-font-color);
+a {
+   color: white;
+   text-decoration: none;
 }
 
 .nav-left-corner {
@@ -28,7 +28,7 @@ body {
     color: var(--font-color);
 }
 
-.main-card {
+.the-pond {
    background: rgb(158,226,255);
    background: radial-gradient(circle, rgba(158,226,255,1) 13%, rgba(138,205,234,1) 57%, rgba(138,205,234,1) 100%);
    border-radius: 200px;
@@ -39,12 +39,44 @@ body {
    font-size: 25px;
 }
 
+.ponder-username {
+
+}
+
+.ponder-text {
+
+}
+
+.comment-username {
+ /* not used at the moment */
+}
+
+.comment-text {
+
+}
+
 .container{
     display: flex;
    height: 100vh;
    width: 100%;
    align-items: center;
    justify-content: center;
+
+}
+
+.comment-btn {
+   
+}
+
+.upvote-btn {
+
+}
+
+.downvote-btn {
+
+}
+
+.go-fishing-btn {
 
 }
 

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -3,9 +3,8 @@
 
 // TODO: find a way to check relative url instead of hardcoding it
 //TODO: Try catch blcok to prevent crash
-// if(window.location.href=="http://localhost:3001/") {
 
-
+if(window.location.pathname=="/") {
         const ponderInput = document.querySelector('.ponder-input');
         const categoryInput = document.querySelector('.category-input');
         const anonymousInput = document.querySelector('#anonymous-check');
@@ -65,4 +64,4 @@
     // }
 
 
-// }
+}

--- a/views/form.handlebars
+++ b/views/form.handlebars
@@ -27,9 +27,9 @@
 {{#each ponder}}
 <div class="card text-white bg-primary mb-3" style="max-width: 50rem;">
 
-    <div class="card-header">{{User.username}} thinks...</div>
+    <div class="card-header ponder-username">{{User.username}} thinks...</div>
     <div class="card-body">
-      <p class="card-text"><a href="/specific/{{id}}">{{body}}</a></p>
+      <p class="card-text ponder-text"><a href="/specific/{{id}}">{{body}}</a></p>
     </div>
   <div>
     {{!-- comment button --}}

--- a/views/form.handlebars
+++ b/views/form.handlebars
@@ -1,4 +1,4 @@
-<figure class="main-card">
+<figure class="the-pond">
         <h1>What's on your mind?</h1>
 <div class="form-floating">
   <textarea class="form-control ponder-input" placeholder="Type your ponder here" id="floatingTextarea"></textarea>
@@ -24,7 +24,33 @@
 <a href = "/random"><button type="button" class="btn btn-danger btn-lg go-fishing-btn">Go fishing!</button></a>
  </figure>
 
+{{#each ponder}}
+<div class="card text-white bg-primary mb-3" style="max-width: 50rem;">
 
+    <div class="card-header">{{User.username}} thinks...</div>
+    <div class="card-body">
+      <p class="card-text"><a href="/specific/{{id}}">{{body}}</a></p>
+    </div>
+  <div>
+    {{!-- comment button --}}
+    <button type="button" class="btn btn-warning"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chat-right-text" viewBox="0 0 16 16">
+    <path d="M2 1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h9.586a2 2 0 0 1 1.414.586l2 2V2a1 1 0 0 0-1-1H2zm12-1a2 2 0 0 1 2 2v12.793a.5.5 0 0 1-.854.353l-2.853-2.853a1 1 0 0 0-.707-.293H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h12z"/>
+    <path d="M3 3.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5zM3 6a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9A.5.5 0 0 1 3 6zm0 2.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5z"/>
+    </svg> Comment</i></button>
+
+  {{!-- Upvote button --}}
+    <button type="button" class="btn btn-success"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-up" viewBox="0 0 16 16">
+    <path d="M8 11a.5.5 0 0 0 .5-.5V6.707l1.146 1.147a.5.5 0 0 0 .708-.708l-2-2a.5.5 0 0 0-.708 0l-2 2a.5.5 0 1 0 .708.708L7.5 6.707V10.5a.5.5 0 0 0 .5.5z"/>
+    <path d="M4 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H4zm0 1h8a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1z"/>
+    </svg> Upvote</button>
+
+  {{!-- Downvote Button --}}
+    <button type="button" class="btn btn-danger"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-down-fill" viewBox="0 0 16 16">
+    <path d="M12 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zM8 5a.5.5 0 0 1 .5.5v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 1 1 .708-.708L7.5 9.293V5.5A.5.5 0 0 1 8 5z"/>
+    </svg> Downvote</button>
+  </div>
+</div>
+{{/each}}
 
  <div class="container">
         <button></button>

--- a/views/ponder.handlebars
+++ b/views/ponder.handlebars
@@ -1,11 +1,10 @@
-<figure class="main-card">
+<figure class="the-pond">
 
 <div class="card text-white bg-primary mb-3" style="max-width: 50rem;">
 
-    <div class="card-header">{{ponder.User.username}} thinks...</div>
+    <div class="card-header ponder-username">{{ponder.User.username}} thinks...</div>
     <div class="card-body">
-
-      <p class="card-text">{{ponder.body}}</p>
+      <p class="card-text ponder-text">{{ponder.body}}</p>
     </div>
   <div>
     {{!-- comment button --}}
@@ -28,24 +27,24 @@
 
     {{#each ponder.Comments}}
     <div class="card-body">
-      <p class="card-text">{{User.username}}: {{body}}</p>
+      <p class="card-text comment-text">{{User.username}}: {{body}}</p>
     </div>
   
   <div>
     {{!-- comment button --}}
-    <button type="button" class="btn btn-warning"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chat-right-text" viewBox="0 0 16 16">
+    <button type="button" class="btn btn-warning comment-btn"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chat-right-text" viewBox="0 0 16 16">
     <path d="M2 1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h9.586a2 2 0 0 1 1.414.586l2 2V2a1 1 0 0 0-1-1H2zm12-1a2 2 0 0 1 2 2v12.793a.5.5 0 0 1-.854.353l-2.853-2.853a1 1 0 0 0-.707-.293H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h12z"/>
     <path d="M3 3.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5zM3 6a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9A.5.5 0 0 1 3 6zm0 2.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5z"/>
     </svg> Comment</i></button>
 
   {{!-- Upvote button --}}
-    <button type="button" class="btn btn-success"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-up" viewBox="0 0 16 16">
+    <button type="button" class="btn btn-success upvote-btn"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-up" viewBox="0 0 16 16">
     <path d="M8 11a.5.5 0 0 0 .5-.5V6.707l1.146 1.147a.5.5 0 0 0 .708-.708l-2-2a.5.5 0 0 0-.708 0l-2 2a.5.5 0 1 0 .708.708L7.5 6.707V10.5a.5.5 0 0 0 .5.5z"/>
     <path d="M4 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H4zm0 1h8a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1z"/>
     </svg> Upvote</button>
 
   {{!-- Downvote Button --}}
-    <button type="button" class="btn btn-danger"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-down-fill" viewBox="0 0 16 16">
+    <button type="button" class="btn btn-danger downvote-btn"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-down-fill" viewBox="0 0 16 16">
     <path d="M12 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zM8 5a.5.5 0 0 1 .5.5v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 1 1 .708-.708L7.5 9.293V5.5A.5.5 0 0 1 8 5z"/>
     </svg> Downvote</button>
   </div>

--- a/views/random.handlebars
+++ b/views/random.handlebars
@@ -2,26 +2,26 @@
 
 <div class="card text-white bg-primary mb-3" style="max-width: 50rem;">
 
-    <div class="card-header">{{ponder.User.username}} thinks...</div>
+    <div class="card-header ponder-username">{{ponder.User.username}} thinks...</div>
     <div class="card-body">
 
-      <p class="card-text">{{ponder.body}}</p>
+      <p class="card-text ponder-text">{{ponder.body}}</p>
     </div>
   <div>
     {{!-- comment button --}}
-    <button type="button" class="btn btn-warning"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chat-right-text" viewBox="0 0 16 16">
+    <button type="button" class="btn btn-warning comment-btn"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chat-right-text" viewBox="0 0 16 16">
     <path d="M2 1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h9.586a2 2 0 0 1 1.414.586l2 2V2a1 1 0 0 0-1-1H2zm12-1a2 2 0 0 1 2 2v12.793a.5.5 0 0 1-.854.353l-2.853-2.853a1 1 0 0 0-.707-.293H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h12z"/>
     <path d="M3 3.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5zM3 6a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9A.5.5 0 0 1 3 6zm0 2.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5z"/>
     </svg> Comment</i></button>
 
   {{!-- Upvote button --}}
-    <button type="button" class="btn btn-success"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-up" viewBox="0 0 16 16">
+    <button type="button" class="btn btn-success upvote-btn"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-up" viewBox="0 0 16 16">
     <path d="M8 11a.5.5 0 0 0 .5-.5V6.707l1.146 1.147a.5.5 0 0 0 .708-.708l-2-2a.5.5 0 0 0-.708 0l-2 2a.5.5 0 1 0 .708.708L7.5 6.707V10.5a.5.5 0 0 0 .5.5z"/>
     <path d="M4 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H4zm0 1h8a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1z"/>
     </svg> Upvote</button>
 
   {{!-- Downvote Button --}}
-    <button type="button" class="btn btn-danger"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-down-fill" viewBox="0 0 16 16">
+    <button type="button" class="btn btn-danger downvote-btn"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-down-fill" viewBox="0 0 16 16">
     <path d="M12 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zM8 5a.5.5 0 0 1 .5.5v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 1 1 .708-.708L7.5 9.293V5.5A.5.5 0 0 1 8 5z"/>
     </svg> Downvote</button>
   </div>

--- a/views/recent.handlebars
+++ b/views/recent.handlebars
@@ -2,33 +2,33 @@
 {{#each ponder}}
 <div class="card text-white bg-primary mb-3" style="max-width: 50rem;">
 
-    <div class="card-header">{{User.username}} thinks...</div>
+    <div class="card-header ponder-username">{{User.username}} thinks...</div>
     <div class="card-body">
 
-      <p class="card-text">{{body}}</p>
+      <p class="card-text ponder-text">{{body}}</p>
     </div>
   <div>
     {{!-- comment button --}}
-    <button type="button" class="btn btn-warning"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chat-right-text" viewBox="0 0 16 16">
+    <button type="button" class="btn btn-warning comment-btn"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chat-right-text" viewBox="0 0 16 16">
     <path d="M2 1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h9.586a2 2 0 0 1 1.414.586l2 2V2a1 1 0 0 0-1-1H2zm12-1a2 2 0 0 1 2 2v12.793a.5.5 0 0 1-.854.353l-2.853-2.853a1 1 0 0 0-.707-.293H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h12z"/>
     <path d="M3 3.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5zM3 6a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9A.5.5 0 0 1 3 6zm0 2.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5z"/>
     </svg> Comment</i></button>
 
   {{!-- Upvote button --}}
-    <button type="button" class="btn btn-success"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-up" viewBox="0 0 16 16">
+    <button type="button" class="btn btn-success upvote-btn"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-up" viewBox="0 0 16 16">
     <path d="M8 11a.5.5 0 0 0 .5-.5V6.707l1.146 1.147a.5.5 0 0 0 .708-.708l-2-2a.5.5 0 0 0-.708 0l-2 2a.5.5 0 1 0 .708.708L7.5 6.707V10.5a.5.5 0 0 0 .5.5z"/>
     <path d="M4 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H4zm0 1h8a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1z"/>
     </svg> Upvote</button>
 
   {{!-- Downvote Button --}}
-    <button type="button" class="btn btn-danger"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-down-fill" viewBox="0 0 16 16">
+    <button type="button" class="btn btn-danger downvote-btn"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-arrow-down-fill" viewBox="0 0 16 16">
     <path d="M12 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zM8 5a.5.5 0 0 1 .5.5v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 1 1 .708-.708L7.5 9.293V5.5A.5.5 0 0 1 8 5z"/>
     </svg> Downvote</button>
   </div>
 
     {{#each Comments}}
     <div class="card-body">
-      <p class="card-text">{{User.username}}: {{body}}</p>
+      <p class="card-text comment-text">{{User.username}}: {{body}}</p>
     </div>
   
   <div>

--- a/views/recent.handlebars
+++ b/views/recent.handlebars
@@ -1,11 +1,11 @@
 <figure class="the-pond">
-
+{{#each ponder}}
 <div class="card text-white bg-primary mb-3" style="max-width: 50rem;">
 
-    <div class="card-header">{{ponder.User.username}} thinks...</div>
+    <div class="card-header">{{User.username}} thinks...</div>
     <div class="card-body">
 
-      <p class="card-text">{{ponder.body}}</p>
+      <p class="card-text">{{body}}</p>
     </div>
   <div>
     {{!-- comment button --}}
@@ -26,7 +26,7 @@
     </svg> Downvote</button>
   </div>
 
-    {{#each ponder.Comments}}
+    {{#each Comments}}
     <div class="card-body">
       <p class="card-text">{{User.username}}: {{body}}</p>
     </div>
@@ -54,4 +54,5 @@
 
 <a href = "/random"><button type="button" class="btn btn-danger btn-lg go-fishing-btn">Go fishing!</button></a>
 <button hidden type="button" class="btn btn-success btn-lg cast-btn">Cast</button>
+{{/each}}
 </figure>


### PR DESCRIPTION
recents aside:

- created separate recent template
- got /api/ponder/ route to render again
- renders three most recent ponders below form
- the respective ponder's body text links to that specific ponder
- it doesn't work with the login layout. right now {{user}} is being passed through that layout

css naming:
- renamed main-card to the-pond
- named: usernames, body text, and buttons in all templates

commented back in the if(window.location.pathname) in index.js